### PR TITLE
Fix multiple ip issues on proxy servers

### DIFF
--- a/src/Swoole/Request.php
+++ b/src/Swoole/Request.php
@@ -127,7 +127,8 @@ class Request extends UtopiaRequest
      */
     public function getIP(): string
     {
-        return trim(explode(',',$this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0')))[0]);
+        $ips = explode(',',$this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0')));
+        return trim($ips[0] ?? '');
     }
 
     /**

--- a/src/Swoole/Request.php
+++ b/src/Swoole/Request.php
@@ -127,7 +127,7 @@ class Request extends UtopiaRequest
      */
     public function getIP(): string
     {
-        return explode(',',$this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0')))[0];
+        return trim(explode(',',$this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0')))[0]);
     }
 
     /**

--- a/src/Swoole/Request.php
+++ b/src/Swoole/Request.php
@@ -127,7 +127,7 @@ class Request extends UtopiaRequest
      */
     public function getIP(): string
     {
-        return $this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0'));
+        return explode(',',$this->getHeader('x-forwarded-for', $this->getServer('remote_addr', '0.0.0.0')))[0];
     }
 
     /**


### PR DESCRIPTION
On a proxy server the header returns comma separated multiple IPs, where the first one is always the user's original IP.