### PR TITLE
Fix chunked Response

### DIFF
--- a/src/Swoole/Response.php
+++ b/src/Swoole/Response.php
@@ -82,7 +82,7 @@ class Response extends UtopiaResponse
             }
             else {
                 for ($i=0; $i < ceil($length / $chunk); $i++) {
-                    $this->swoole->write(substr($body, ($i * $chunk), min((($i * $chunk) + $chunk), $length)));
+                    $this->swoole->write(substr($body, ($i * $chunk), min($chunk, $length - ($i * $chunk))));
                 }
 
                 $this->swoole->end();


### PR DESCRIPTION
Fixed a simple error in `substr` function for chunked response that was causing the large files response to behave weirdly