### PR TITLE
feat: expand support for Redis Pool connections

### DIFF
--- a/src/Swoole/Database/RedisConfig.php
+++ b/src/Swoole/Database/RedisConfig.php
@@ -6,23 +6,23 @@ use Swoole\Database\RedisConfig as SwooleRedisConfig;
 
 class RedisConfig extends SwooleRedisConfig
 {
-    /** @var string|array */
-    protected $auth = '';
+    /** @var array */
+    protected $userauth = [];
 
     /**
-     * @param string|array $auth
+     * @param array $auth
      */
-    public function withAuth($auth): self
+    public function withUserAuth(array $userauth): self
     {
-        $this->auth = $auth;
+        $this->userauth = $userauth;
         return $this;
     }
 
     /**
      * @return string|array $auth
      */
-    public function getAuth()
+    public function getUserAuth(): array
     {
-        return $this->auth;
+        return $this->userauth;
     }
 }

--- a/src/Swoole/Database/RedisConfig.php
+++ b/src/Swoole/Database/RedisConfig.php
@@ -17,4 +17,12 @@ class RedisConfig extends SwooleRedisConfig
         $this->auth = $auth;
         return $this;
     }
+
+    /**
+     * @return string|array $auth
+     */
+    public function getAuth()
+    {
+        return $this->auth;
+    }
 }

--- a/src/Swoole/Database/RedisConfig.php
+++ b/src/Swoole/Database/RedisConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Utopia\Swoole\Database;
+
+use Swoole\Database\RedisConfig as SwooleRedisConfig;
+
+class RedisConfig extends SwooleRedisConfig
+{
+    /** @var string|array */
+    protected $auth = '';
+
+    /**
+     * @param string|array $auth
+     */
+    public function withAuth($auth): self
+    {
+        $this->auth = $auth;
+        return $this;
+    }
+}

--- a/src/Swoole/Database/RedisPool.php
+++ b/src/Swoole/Database/RedisPool.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Utopia\Swoole\Database;
+
+use Redis;
+use Swoole\ConnectionPool;
+use Utopia\Swoole\Database\RedisConfig;
+
+class RedisPool extends ConnectionPool
+{
+    /** @var RedisConfig */
+    protected $config;
+
+    public function __construct(RedisConfig $config, int $size = self::DEFAULT_SIZE)
+    {
+        $this->config = $config;
+        parent::__construct(function () {
+            $redis = new Redis();
+
+            $arguments = [
+                $this->config->getHost(),
+                $this->config->getPort(),
+            ];
+            if ($this->config->getTimeout() !== 0.0) {
+                $arguments[] = $this->config->getTimeout();
+            }
+            if ($this->config->getRetryInterval() !== 0) {
+                /* reserved should always be NULL */
+                $arguments[] = null;
+                $arguments[] = $this->config->getRetryInterval();
+            }
+            if ($this->config->getReadTimeout() !== 0.0) {
+                $arguments[] = $this->config->getReadTimeout();
+            }
+            $redis->connect(...$arguments);
+            if ($this->config->getAuth()) {
+                $redis->auth($this->config->getAuth());
+            }
+            if ($this->config->getUserAuth()) {
+                $redis->auth($this->config->getUserAuth());
+            }
+            if ($this->config->getDbIndex() !== 0) {
+                $redis->select($this->config->getDbIndex());
+            }
+            return $redis;
+        }, $size);
+    }
+}


### PR DESCRIPTION
This PR extends `Swoole\Database\RedisConfig` to support userpass auth via separate `$userauth` methods. 

This PR uses `Swoole\Database\RedisPool` as a model to create a custom `Swoole\ConnectionPool` that supports userpass auth over TLS.

# Issues
- [ ] I messed something up here, because when I try to import this lib in Appwrite, all containers that `require_once app/init.php` max out all cores when trying to use composer's autoloader. I don't even know where to begin troubleshooting this one.